### PR TITLE
#47 - 다른 아이템으로 넘어갈 때 backgroundColor가 초기화 되지 않는 문제 해결

### DIFF
--- a/app/src/main/java/com/nexters/ticktock/timer/TimerActivity.kt
+++ b/app/src/main/java/com/nexters/ticktock/timer/TimerActivity.kt
@@ -222,6 +222,7 @@ class TimerActivity : AppCompatActivity() {
         expiredTimeIdx = 0
         mPreferences.setStartedTime(0)
         mTimeToGo = TIMER_LENGTH
+        binding.timerLayout.setBackgroundColor(Color.parseColor("#ffffff"))
         updateCountDownText()
     }
 


### PR DESCRIPTION
다음 아이템으로 넘어갈 때 backgroundColor가 초기화 되지 않는 문제 해결하였습니다.